### PR TITLE
feat(task): ThreadAffinity + MainThreadPump for DCC/game-engine hosts (#47)

### DIFF
--- a/.agents/skills/vx-best-practices/SKILL.md
+++ b/.agents/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.agents/skills/vx-commands/SKILL.md
+++ b/.agents/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.agents/skills/vx-project/SKILL.md
+++ b/.agents/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.agents/skills/vx-troubleshooting/SKILL.md
+++ b/.agents/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.agents/skills/vx-usage/SKILL.md
+++ b/.agents/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.claude/skills/vx-best-practices/SKILL.md
+++ b/.claude/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.claude/skills/vx-commands/SKILL.md
+++ b/.claude/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.claude/skills/vx-project/SKILL.md
+++ b/.claude/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.claude/skills/vx-troubleshooting/SKILL.md
+++ b/.claude/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.claude/skills/vx-usage/SKILL.md
+++ b/.claude/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.cline/skills/vx-best-practices/SKILL.md
+++ b/.cline/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.cline/skills/vx-commands/SKILL.md
+++ b/.cline/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.cline/skills/vx-project/SKILL.md
+++ b/.cline/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.cline/skills/vx-troubleshooting/SKILL.md
+++ b/.cline/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.cline/skills/vx-usage/SKILL.md
+++ b/.cline/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.codebuddy/skills/vx-best-practices/SKILL.md
+++ b/.codebuddy/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.codebuddy/skills/vx-commands/SKILL.md
+++ b/.codebuddy/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.codebuddy/skills/vx-project/SKILL.md
+++ b/.codebuddy/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.codebuddy/skills/vx-troubleshooting/SKILL.md
+++ b/.codebuddy/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.codebuddy/skills/vx-usage/SKILL.md
+++ b/.codebuddy/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.cursor/skills/vx-best-practices/SKILL.md
+++ b/.cursor/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.cursor/skills/vx-commands/SKILL.md
+++ b/.cursor/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.cursor/skills/vx-project/SKILL.md
+++ b/.cursor/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.cursor/skills/vx-troubleshooting/SKILL.md
+++ b/.cursor/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.cursor/skills/vx-usage/SKILL.md
+++ b/.cursor/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.kiro/skills/vx-best-practices/SKILL.md
+++ b/.kiro/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.kiro/skills/vx-commands/SKILL.md
+++ b/.kiro/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.kiro/skills/vx-project/SKILL.md
+++ b/.kiro/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.kiro/skills/vx-troubleshooting/SKILL.md
+++ b/.kiro/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.kiro/skills/vx-usage/SKILL.md
+++ b/.kiro/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.opencode/skills/vx-best-practices/SKILL.md
+++ b/.opencode/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.opencode/skills/vx-commands/SKILL.md
+++ b/.opencode/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.opencode/skills/vx-project/SKILL.md
+++ b/.opencode/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.opencode/skills/vx-troubleshooting/SKILL.md
+++ b/.opencode/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.opencode/skills/vx-usage/SKILL.md
+++ b/.opencode/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.roo/skills/vx-best-practices/SKILL.md
+++ b/.roo/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.roo/skills/vx-commands/SKILL.md
+++ b/.roo/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.roo/skills/vx-project/SKILL.md
+++ b/.roo/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.roo/skills/vx-troubleshooting/SKILL.md
+++ b/.roo/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.roo/skills/vx-usage/SKILL.md
+++ b/.roo/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.trae/skills/vx-best-practices/SKILL.md
+++ b/.trae/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.trae/skills/vx-commands/SKILL.md
+++ b/.trae/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.trae/skills/vx-project/SKILL.md
+++ b/.trae/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.trae/skills/vx-troubleshooting/SKILL.md
+++ b/.trae/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.trae/skills/vx-usage/SKILL.md
+++ b/.trae/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/.windsurf/skills/vx-best-practices/SKILL.md
+++ b/.windsurf/skills/vx-best-practices/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: vx-best-practices
+description: "Best practices for using vx effectively. Use when following recommended patterns for tool management, project setup, and team workflows with vx."
+---
+
+# VX Best Practices
+
+> **Golden rule**: Always prefix tool commands with `vx` in vx-managed projects. Use `vx.toml` for project-level tool versions, commit `vx.lock` for reproducibility, and prefer templates over custom code when creating providers.
+
+## General Principles
+
+### 1. Always Use `vx` Prefix
+
+In vx-managed projects, always prefix tool commands with `vx`:
+
+```bash
+# ✅ Correct
+vx npm install
+vx cargo build
+vx just test
+
+# ❌ Wrong (might use system tools)
+npm install
+cargo build
+just test
+```
+
+### 2. Prefer Project-Level Configuration
+
+Use `vx.toml` to ensure consistency across team members:
+
+```bash
+# ✅ Correct - defined in vx.toml
+vx sync
+
+# ❌ Wrong - manual installation
+vx install node@22
+```
+
+### 3. Commit Lock Files
+
+Always commit `vx.lock` to ensure reproducible builds:
+
+```bash
+git add vx.lock
+git commit -m "chore: update dependencies"
+```
+
+## Project Setup
+
+### Initial Setup
+
+```bash
+# 1. Initialize project
+vx init
+
+# 2. Add required tools
+vx add node@22
+vx add go
+vx add just
+
+# 3. Generate lock file
+vx lock
+
+# 4. Commit configuration
+git add vx.toml vx.lock
+```
+
+### Team Onboarding
+
+New team members only need to run:
+
+```bash
+# Clone repository
+git clone <repo>
+cd <repo>
+
+# One command setup
+vx setup
+```
+
+### CI/CD Configuration
+
+Use the vx GitHub Action:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'
+    cache: 'true'
+```
+
+## Version Management
+
+### Version Selection Strategy
+
+| Scenario | Constraint | Example |
+|----------|------------|---------|
+| Development | Major version | `node = "22"` |
+| CI/CD | Exact version | `node = "22.0.0"` |
+| Library | Range | `node = ">=18 <23"` |
+| Latest features | `"latest"` | `uv = "latest"` |
+
+### Avoid Over-Specification
+
+```toml
+# ✅ Good - flexible for patch updates
+[tools]
+node = "22"
+go = "1.22"
+
+# ❌ Bad - too rigid for development
+[tools]
+node = "22.0.0"    # Blocks security patches
+go = "1.22.0"      # Requires update for each patch
+```
+
+### LTS for Production
+
+```toml
+# Use LTS versions for stability
+[tools]
+node = "lts"        # Auto-updates to latest LTS
+```
+
+## Scripts Organization
+
+### Naming Conventions
+
+```toml
+[scripts]
+# Standard scripts (run with: vx run <name>)
+dev = "npm run dev"
+test = "npm run test"
+build = "npm run build"
+lint = "npm run lint"
+
+# Colon-separated variants (run with: vx run test:watch)
+test:watch = "npm run test -- --watch"
+test:coverage = "npm run test -- --coverage"
+build:prod = "npm run build -- --mode production"
+
+# CI-specific scripts
+ci = "just ci"
+ci:test = "cargo test --all-features"
+```
+
+### Script Dependencies
+
+```toml
+# Scripts can depend on specific tools
+[scripts]
+lint = "eslint . && cargo clippy"  # Uses node and rust
+build = "go build ./..."           # Uses go
+```
+
+## Environment Variables
+
+### Project-Level Defaults
+
+```toml
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+
+# Required variables (vx will warn if missing)
+API_KEY = { env = "API_KEY", required = true }
+
+# Default values
+PORT = { default = "3000" }
+```
+
+### Secrets Management
+
+Never commit secrets. Use environment variables:
+
+```bash
+# .env (add to .gitignore)
+DATABASE_URL=postgresql://...
+API_KEY=secret123
+
+# Reference in vx.toml
+[env]
+DATABASE_URL = { env = "DATABASE_URL" }
+```
+
+## Performance Optimization
+
+### Cache Configuration
+
+```toml
+[cache]
+# Enable aggressive caching
+enabled = true
+ttl = 86400  # 24 hours
+
+# Cache location
+dir = "~/.vx/cache"
+```
+
+### Pre-install Common Tools
+
+```bash
+# In project setup, pre-install tools
+vx sync --parallel
+```
+
+### Use Offline Mode
+
+```bash
+# When network is unreliable
+vx sync --offline
+```
+
+## Cross-Platform Considerations
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools first
+node = "22"
+uv = "latest"
+
+# Platform-specific
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+### Cross-Platform Scripts
+
+```bash
+# Use tools that work everywhere
+[scripts]
+build = "just build"     # just is cross-platform
+test = "cargo test"      # cargo is cross-platform
+
+# Avoid platform-specific commands
+# ❌ build = "make build"  # Unix only
+```
+
+## Security Best Practices
+
+### Verify Checksums
+
+vx automatically verifies checksums. For additional security:
+
+```bash
+# Verify installation
+vx install node@22 --verify
+```
+
+### Minimal Permissions
+
+```bash
+# Install as regular user, not root
+# ❌ sudo vx install node
+
+# vx manages user-level installations
+vx install node
+```
+
+### Audit Dependencies
+
+```bash
+# Audit installed tools
+vx audit
+
+# Check for vulnerabilities
+vx npm audit
+```
+
+## Team Workflows
+
+### Adding New Tools
+
+```bash
+# 1. Add to vx.toml
+vx add python@3.12
+
+# 2. Update lock file
+vx lock
+
+# 3. Commit changes
+git add vx.toml vx.lock
+git commit -m "feat: add python 3.12"
+```
+
+### Updating Tools
+
+```bash
+# 1. Check for updates
+vx outdated
+
+# 2. Update specific tool
+vx update node
+
+# 3. Update all tools
+vx update --all
+
+# 4. Commit lock file changes
+git add vx.lock
+```
+
+### Removing Tools
+
+```bash
+# 1. Remove from vx.toml
+vx remove tool-name
+
+# 2. Clean up installation
+vx sync --clean
+
+# 3. Commit changes
+git add vx.toml vx.lock
+```
+
+## Monitoring & Maintenance
+
+### Regular Checks
+
+```bash
+# Weekly: Check for updates
+vx outdated
+
+# Monthly: Clean cache
+vx cache clean
+
+# After issues: Run diagnostics
+vx doctor
+```
+
+### Health Check Script
+
+```toml
+[scripts]
+doctor = "vx doctor"
+check = "vx check"
+audit = "vx npm audit && cargo audit"
+```
+
+## Anti-Patterns to Avoid
+
+### 1. Manual Tool Installation
+
+```bash
+# ❌ Don't manually install tools in vx projects
+npm install -g node  # Conflicts with vx
+
+# ✅ Let vx manage tools
+vx npm install
+```
+
+### 2. Ignoring Lock Files
+
+```bash
+# ❌ Don't ignore vx.lock
+git rm --cached vx.lock
+
+# ✅ Always commit lock files
+git add vx.lock
+```
+
+### 3. Global vx.toml
+
+```bash
+# ❌ Don't rely on global configuration
+~/.vx/vx.toml
+
+# ✅ Use project-level configuration
+./vx.toml
+```
+
+### 4. Hardcoded Paths
+
+```toml
+# ❌ Don't hardcode absolute paths
+[env]
+TOOL_PATH = "/Users/alice/.vx/tools/node"
+
+# ✅ Use vx variables
+[env]
+TOOL_PATH = "${VX_ROOT}/tools/node"
+```
+
+## Migration Guide
+
+### From nvm/fnm → vx
+
+```bash
+# 1. Export current versions
+node --version > .nvmrc
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add node version
+vx add node@$(cat .nvmrc | tr -d 'v')
+
+# 4. Remove nvm
+rm -rf ~/.nvm
+```
+
+### From pyenv → vx
+
+```bash
+# 1. Check current Python version
+python --version
+
+# 2. Create vx.toml
+vx init
+
+# 3. Add uv (recommended Python manager)
+vx add uv
+
+# 4. Remove pyenv
+rm -rf ~/.pyenv
+```
+
+## Provider Development Best Practices
+
+### Choose the Right Template
+
+**Decision tree for new providers**:
+- Tool releases on GitHub with Rust target triple? → `github_rust_provider` (most common)
+- Tool releases on GitHub with Go goreleaser? → `github_go_provider`
+- Single binary download (no archive)? → `github_binary_provider`
+- System package manager only? → `system_provider`
+- Custom download source? → Hand-write `download_url` function
+
+For most tools, use a template instead of writing custom functions:
+
+```starlark
+# ✅ Good — Use template (10 lines)
+_p = github_rust_provider("owner", "tool",
+    asset = "tool-{vversion}-{triple}.{ext}")
+
+# ❌ Avoid — Custom download_url when template works
+def download_url(ctx, version):
+    # 30+ lines of custom code...
+```
+
+### Understanding the ctx Object
+
+All provider.star functions receive a `ctx` object:
+
+| Field | Example value | Description |
+|-------|--------------|-------------|
+| `ctx.platform.os` | `"windows"`, `"macos"`, `"linux"` | Current OS |
+| `ctx.platform.arch` | `"x64"`, `"arm64"` | CPU architecture |
+| `ctx.install_dir` | `~/.vx/store/node/22.0.0` | Install path |
+| `ctx.store_dir` | `~/.vx/store` | Global store root |
+| `ctx.cache_dir` | `~/.vx/cache` | Cache directory |
+
+### Provider Naming
+
+```starlark
+# ✅ Correct terminology
+name = "ripgrep"              # Provider name
+runtimes = [runtime_def("rg")]  # Runtime name (what user types)
+
+# Common pattern: provider name = project name, runtime name = binary name
+# ripgrep provider → rg runtime
+# rust provider → cargo, rustc, rustup runtimes
+```
+
+### Platform Constraints
+
+Return `None` from `download_url` for unsupported platforms:
+
+```starlark
+def download_url(ctx, version):
+    platform = platform_map(ctx, _PLATFORMS)
+    if not platform:
+        return None  # Not supported on this platform
+    return "https://example.com/v{}/tool-{}.tar.gz".format(version, platform)
+```
+
+### Bundled Runtimes
+
+Use `bundled_runtime_def` for tools shipped inside another:
+
+```starlark
+runtimes = [
+    runtime_def("node"),                     # Primary runtime
+    bundled_runtime_def("npm", "node"),       # npm comes with node
+    bundled_runtime_def("npx", "node"),       # npx comes with node
+]
+```
+
+## vx Development Best Practices
+
+### Quick Development Cycle
+
+```bash
+vx just quick                    # format → lint → test → build
+vx cargo check -p vx-cli         # Fast type-checking for one crate
+vx cargo test -p vx-starlark     # Test one crate
+```
+
+### Code Organization Rules
+
+1. **Layer dependencies go downward only** — Never import from higher layers
+2. **Tests in `tests/` directories** — Never inline `#[cfg(test)]`
+3. **Use `rstest`** for parameterized tests
+4. **Use `tracing`** for logging, never `println!` or `eprintln!`
+5. **Use correct terminology** — Runtime, Provider, provider.star
+
+## AI Agent Documentation Ecosystem
+
+vx maintains a comprehensive set of AI agent configuration files for 15+ agents:
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `AGENTS.md` | Primary AI agent entry point — rules, architecture, quick reference | All AI coding agents (official standard) |
+| `CLAUDE.md` | Claude Code specific instructions with `@`-import support | Claude Code |
+| `llms.txt` | Concise LLM-friendly project index (llmstxt.org protocol) | LLMs discovering the project |
+| `llms-full.txt` | Detailed LLM documentation with full examples | LLMs needing deep context |
+| `.github/copilot-instructions.md` | GitHub Copilot-specific instructions | GitHub Copilot |
+| `.cursor/rules/*.mdc` | Modern Cursor IDE rules with YAML frontmatter (4 files) | Cursor AI (new format) |
+| `.cursorrules` | Cursor IDE agent rules (legacy format, still supported) | Cursor AI (legacy) |
+| `.clinerules` | Cline/Roo agent rules | Cline |
+| `.windsurfrules` | Windsurf AI IDE rules | Windsurf |
+| `.kiro/steering/*.md` | Kiro AI IDE steering documents | Kiro |
+| `.trae/rules/*.md` | Trae AI IDE project rules | Trae |
+| `skills/` | Distributable skill files for 15+ AI agents | ClawHub, vx ai setup |
+
+**Best practice**: When making changes that affect AI agent behavior (terminology, architecture, commands), update `AGENTS.md` first — it is the single source of truth. Other files derive from it.

--- a/.windsurf/skills/vx-commands/SKILL.md
+++ b/.windsurf/skills/vx-commands/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: vx-commands
+description: "Complete vx CLI command reference. Use when looking up specific vx command syntax, flags, or output formats. All commands support --json for structured output and --format toon for token-optimized output."
+---
+
+# VX Command Reference
+
+> **Quick rule**: All vx commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens). Set `VX_OUTPUT=json` to default all commands to JSON.
+
+## Structured Output Commands (AI-Optimized)
+
+All commands support `--json` for structured output and `--format toon` for token-optimized output (saves 40-60% tokens).
+
+### Project Analysis
+
+```bash
+vx analyze --json           # Analyze project structure
+vx check --json             # Verify tool constraints
+vx ai context --json        # Generate AI-friendly project context
+```
+
+**Output fields (analyze)**:
+- `ecosystems[]` - Detected ecosystems (nodejs, python, rust, go)
+- `dependencies[]` - Project dependencies
+- `scripts[]` - Available scripts
+- `required_tools[]` - Tools needed
+
+**Output fields (check)**:
+- `requirements[]` - Tool requirement status
+- `all_satisfied` - Whether all constraints are met
+- `missing_tools[]` - Tools that need installation
+
+**Output fields (ai context)**:
+- `project` - Project info (name, languages, frameworks)
+- `tools[]` - Installed tools with versions
+- `scripts[]` - Available scripts
+- `constraints[]` - Tool constraints
+
+### Tool Management
+
+```bash
+vx list --json              # List installed tools
+vx versions node --json     # List available versions
+vx which node --json        # Find tool location
+vx search <query> --json    # Search for tools
+```
+
+**Output fields (list)**:
+- `runtimes[]` - Available runtimes
+- `total` - Total count
+- `installed_count` - Installed count
+
+**Output fields (versions)**:
+- `versions[]` - Available versions with metadata
+- `latest` - Latest version
+- `lts` - LTS version (if applicable)
+
+**Output fields (which)**:
+- `path` - Executable path
+- `version` - Resolved version
+- `source` - Source (vx, system, global_package)
+
+### Installation
+
+```bash
+vx install node@22 --json   # Install tool
+vx sync --json              # Sync from vx.toml
+```
+
+**Output fields (install)**:
+- `runtime` - Tool name
+- `version` - Installed version
+- `path` - Installation path
+- `duration_ms` - Installation duration
+- `dependencies_installed[]` - Dependencies also installed
+
+**Output fields (sync)**:
+- `installed[]` - Successfully installed
+- `skipped[]` - Skipped (already installed)
+- `failed[]` - Failed installations
+- `duration_ms` - Total duration
+
+### AI Integration
+
+```bash
+vx ai context               # Generate AI-friendly context (Markdown)
+vx ai context --json        # JSON format
+vx ai context --minimal     # Minimal output
+vx ai session init          # Initialize session state
+vx ai session status        # Show session status
+vx ai session cleanup       # Clean up session
+```
+
+### Environment
+
+```bash
+vx env --json               # Show environment variables
+vx dev --export             # Export shell environment
+```
+
+## Output Formats
+
+### JSON Format
+```bash
+vx list --json
+# Output: {"runtimes": [...], "total": 50, "installed_count": 5}
+```
+
+### TOON Format (Token-Optimized)
+```bash
+vx list --format toon
+# Output:
+# runtimes[50]{name,installed,description}:
+#   node,true,Node.js runtime
+#   python,false,Python runtime
+#   ...
+```
+
+TOON format is recommended for AI agents - it saves 40-60% tokens compared to JSON.
+
+### Environment Variable
+```bash
+export VX_OUTPUT=json       # Default to JSON output
+export VX_OUTPUT=toon       # Default to TOON output
+```
+
+## Command Groups
+
+### Tool Execution
+```bash
+vx <tool> [args...]         # Run any tool
+vx npm install              # Run npm
+vx cargo build              # Run cargo
+```
+
+### Advanced Execution Syntax
+```bash
+# Runtime with version
+vx node@22 app.js                     # Use specific Node.js version
+
+# Runtime executable override
+vx msvc@14.42::cl main.cpp            # Run cl from MSVC runtime
+
+# Package execution (ecosystem:package pattern)
+vx npm:vite                            # Run vite via npm
+vx uv:ruff check .                    # Run ruff via uv
+vx npm:typescript@5.0::tsc            # Run tsc from specific typescript version
+
+# Package aliases (shortcuts)
+vx vite                                # Same as: vx npm:vite
+vx meson                              # Same as: vx uv:meson
+
+# Multi-runtime composition
+vx --with bun@1.1 --with deno node app.js   # Multiple runtimes in PATH
+```
+
+### Tool Management
+```bash
+vx install <tool>@<version> # Install tool
+vx uninstall <tool>         # Uninstall tool
+vx list                     # List tools
+vx versions <tool>          # Show versions
+vx which <tool>             # Find tool path
+vx switch <tool>@<version>  # Switch version
+```
+
+### Project Management
+```bash
+vx init                     # Initialize vx.toml
+vx add <tool>               # Add tool to project
+vx remove <tool>            # Remove tool from project
+vx sync                     # Sync tools from vx.toml
+vx lock                     # Generate vx.lock
+vx check                    # Check constraints
+```
+
+### Script Execution
+```bash
+vx run <script>             # Run script from vx.toml
+vx run --list               # List available scripts
+```
+
+### Cache Management
+```bash
+vx cache dir                # Show cache directory
+vx cache clean              # Clean cache
+```
+
+## Global Flags
+
+```bash
+--json                      # JSON output
+--format <text|json|toon>   # Output format
+--verbose                   # Verbose output
+--debug                     # Debug output
+--use-system-path           # Use system PATH
+--cache-mode <mode>         # Cache mode (normal, refresh, offline, no-cache)
+```
+
+## Exit Codes
+
+- `0` - Success
+- `1` - General error
+- `2` - Tool not found
+- `3` - Installation failed
+- `4` - Version not found
+- `5` - Network error
+- `6` - Permission error
+- `7` - Configuration error

--- a/.windsurf/skills/vx-project/SKILL.md
+++ b/.windsurf/skills/vx-project/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: vx-project
+description: "Project management guide for vx. Use when setting up a new project, configuring vx.toml, or managing project-level tool versions and scripts."
+---
+
+# VX Project Management Guide
+
+> **Quick start**: Run `vx init` to create `vx.toml`, `vx setup` to install all tools, `vx dev` to enter the dev environment. For existing projects, just run `vx setup` after cloning.
+
+## Project Setup
+
+### Initialize a Project
+
+```bash
+vx init                     # Create vx.toml interactively
+vx init --template node     # Use a template
+vx init --minimal           # Create minimal vx.toml
+```
+
+### Project Detection
+
+vx automatically detects project types and suggests tools:
+
+```bash
+vx analyze                  # Analyze project (detects languages, dependencies)
+vx analyze --json           # JSON output for AI parsing
+```
+
+**Detected ecosystems**: Node.js, Python, Rust, Go, Java, .NET, C/C++, Zig
+**Detected frameworks**: React, Vue, Angular, Next.js, Nuxt, Svelte, Django, Flask, FastAPI, Tauri, Electron, React Native, NW.js, and more
+**Detected package managers**: npm, yarn, pnpm, bun, pip, uv, cargo, go modules
+
+The project analyzer reads indicator files like `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc. to suggest the right tools.
+
+## vx.toml Configuration
+
+### Basic Structure
+
+```toml
+# vx.toml - Project tool configuration
+
+[tools]
+# Version constraints
+node = "22"                 # Major version (any 22.x.x)
+go = "1.22"                 # Minor version (any 1.22.x)
+uv = "latest"               # Always use latest
+rust = "1.80"               # Specific version
+just = "*"                  # Any version
+
+# Platform-specific tools
+[tools.msvc]
+version = "14.42"
+os = ["windows"]            # Only install on Windows
+
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+
+[scripts]
+# Development scripts
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+# CI/CD scripts
+ci = "just ci"
+release = "just release"
+
+[hooks]
+# Lifecycle hooks
+pre_commit = ["vx run lint"]
+post_setup = ["npm install", "cargo fetch"]
+```
+
+### Version Constraints
+
+| Constraint | Example | Meaning |
+|------------|---------|---------|
+| Exact | `"1.2.3"` | Only version 1.2.3 |
+| Major | `"1"` | Any 1.x.x |
+| Minor | `"1.2"` | Any 1.2.x |
+| Latest | `"latest"` | Always latest |
+| Any | `"*"` | Any available version |
+| Range | `">=1.0.0 <2.0.0"` | Range constraint |
+
+### Platform-Specific Tools
+
+```toml
+[tools]
+# Cross-platform tools
+node = "22"
+uv = "latest"
+
+# Windows-only
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+
+# macOS/Linux only
+[tools.brew]
+version = "latest"
+os = ["macos", "linux"]
+```
+
+## Project Commands
+
+### Setup & Sync
+
+```bash
+vx setup                    # Full project setup (sync + hooks)
+vx sync                     # Install all tools from vx.toml
+vx sync --clean             # Remove unlisted tools
+vx sync --check             # Check without installing
+```
+
+### Running Scripts
+
+```bash
+vx run dev                  # Run development server
+vx run test                 # Run tests
+vx run build                # Build project
+vx run --list               # List available scripts
+```
+
+### Lock File
+
+```bash
+vx lock                     # Generate vx.lock
+vx lock --update            # Update locked versions
+vx lock --check             # Verify lock file
+```
+
+The `vx.lock` file ensures reproducible builds:
+
+```toml
+# vx.lock - Auto-generated, do not edit
+[tools]
+node = { version = "22.0.0", checksum = "sha256:..." }
+go = { version = "1.22.0", checksum = "sha256:..." }
+```
+
+## Environment Management
+
+### Project Environment
+
+```bash
+vx dev                      # Enter project environment
+vx env list                 # List environments
+vx env activate             # Print activation commands
+eval $(vx env activate)     # Activate in shell
+```
+
+### Environment Variables
+
+Define in `vx.toml`:
+
+```toml
+[env]
+NODE_ENV = "development"
+DATABASE_URL = "postgresql://localhost:5432/dev"
+API_KEY = { env = "API_KEY", required = true }
+```
+
+## Dependency Management
+
+### Add/Remove Tools
+
+```bash
+vx add node@22              # Add tool to vx.toml
+vx add go rust uv           # Add multiple tools
+vx remove node              # Remove tool from vx.toml
+```
+
+### Check Constraints
+
+```bash
+vx check                    # Verify tool constraints
+vx check --json             # JSON output
+vx check --fix              # Auto-fix issues
+```
+
+## Multi-Package Projects
+
+### Monorepo Support
+
+For monorepos, create `vx.toml` in root:
+
+```toml
+# Root vx.toml
+[tools]
+node = "22"
+pnpm = "latest"
+
+[scripts]
+install = "pnpm install"
+build = "pnpm -r build"
+test = "pnpm -r test"
+```
+
+### Workspace Packages
+
+Individual packages can have their own `vx.toml`:
+
+```toml
+# packages/backend/vx.toml
+[tools]
+go = "1.22"
+
+[scripts]
+dev = "go run ./cmd/server"
+```
+
+## Best Practices
+
+### 1. Version Pinning
+
+Pin versions for CI/CD:
+
+```toml
+[tools]
+node = "22.0.0"             # Exact version for CI
+```
+
+### 2. Lock Files
+
+Always commit `vx.lock`:
+
+```bash
+git add vx.lock
+```
+
+### 3. Scripts Organization
+
+Group related scripts:
+
+```toml
+[scripts]
+# Development
+dev = "..."
+watch = "..."
+
+# Testing
+test = "..."
+test:watch = "..."
+
+# Build
+build = "..."
+build:prod = "..."
+```
+
+### 4. Hooks for Quality
+
+Use hooks for automated checks:
+
+```toml
+[hooks]
+pre_commit = ["vx run lint", "vx run test"]
+post_checkout = ["vx sync"]
+```
+
+## Project Templates
+
+Create reusable templates:
+
+```bash
+# Create template from current project
+vx template create my-template
+
+# Use template
+vx init --template my-template
+```
+
+### Template Structure
+
+```
+~/.vx/templates/my-template/
+├── vx.toml
+├── .gitignore
+├── README.md
+└── hooks/
+    └── post_setup.sh
+```

--- a/.windsurf/skills/vx-troubleshooting/SKILL.md
+++ b/.windsurf/skills/vx-troubleshooting/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: vx-troubleshooting
+description: "Troubleshooting guide for vx issues. Use when encountering installation failures, version conflicts, PATH issues, or other vx problems."
+---
+
+# VX Troubleshooting Guide
+
+> **Quick triage**: Start with `vx doctor` for diagnostics. Use `vx --debug <command>` for detailed logs. Use `vx cache clean` to clear corrupted state. Check exit codes (2=tool not found, 3=install failed, 4=version not found, 5=network error).
+
+## Common Issues
+
+### Installation Failures
+
+#### Tool Download Failed
+
+**Symptoms**: `Failed to download <tool>: network error` or `Connection refused`
+
+**Solutions**:
+
+```bash
+# Enable CDN acceleration (China users)
+vx config set cdn_acceleration true
+
+# Use mirror
+vx install node --mirror https://npmmirror.com/mirrors/node
+
+# Retry with verbose output
+vx install node --verbose --debug
+
+# Check cache and retry
+vx cache clean
+vx install node
+```
+
+#### Checksum Mismatch
+
+**Symptoms**: `Checksum mismatch: expected X, got Y`
+
+**Solutions**:
+
+```bash
+# Clear corrupted download
+vx cache clean
+
+# Reinstall with fresh download
+vx install node@22 --force
+```
+
+#### Permission Denied
+
+**Symptoms**: `Permission denied` or `Access is denied`
+
+**Solutions**:
+
+```bash
+# Check VX_HOME permissions
+ls -la ~/.vx
+
+# Fix permissions (Unix)
+chmod -R u+rw ~/.vx
+
+# Run with elevated permissions if needed
+sudo vx install node  # Not recommended, use user installation
+```
+
+### Version Issues
+
+#### Version Not Found
+
+**Symptoms**: `Version X not found for <tool>`
+
+**Solutions**:
+
+```bash
+# List available versions
+vx versions node
+
+# Use latest stable
+vx install node@latest
+
+# Use LTS version
+vx install node@lts
+
+# Check for typos
+vx versions node | grep "20"
+```
+
+#### Version Conflict
+
+**Symptoms**: Multiple versions installed, wrong version active
+
+**Solutions**:
+
+```bash
+# List installed versions
+vx list node --installed
+
+# Switch to specific version
+vx switch node@20
+
+# Check which version is active
+vx which node
+
+# Remove conflicting versions
+vx uninstall node@18
+```
+
+### PATH Issues
+
+#### Command Not Found
+
+**Symptoms**: `command not found: node` after installation
+
+**Solutions**:
+
+```bash
+# Verify vx shim directory is in PATH
+echo $PATH | grep -o ".vx/bin"
+
+# Add vx to PATH (add to shell config)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx directly
+vx node --version
+
+# Check shim exists
+ls ~/.vx/bin/node
+```
+
+#### Wrong Version in PATH
+
+**Symptoms**: System version takes precedence over vx version
+
+**Solutions**:
+
+```bash
+# Check which executable is being used
+which node
+vx which node
+
+# Reorder PATH (vx should come first)
+export PATH="$HOME/.vx/bin:$PATH"
+
+# Or use vx explicitly
+vx node --version
+```
+
+### Runtime Issues
+
+#### Tool Crashes on Startup
+
+**Symptoms**: Tool exits immediately or crashes
+
+**Solutions**:
+
+```bash
+# Check tool version
+vx which node
+vx node --version
+
+# Reinstall the tool
+vx install node --force
+
+# Check for missing dependencies
+vx doctor
+
+# Try with debug output
+vx node --verbose script.js
+```
+
+#### Dependency Missing
+
+**Symptoms**: `error while loading shared libraries` or `DLL not found`
+
+**Solutions**:
+
+```bash
+# Check dependencies (Linux)
+ldd $(vx which node)
+
+# Install system dependencies
+# Ubuntu/Debian
+sudo apt-get install build-essential libssl-dev
+
+# macOS (via Homebrew)
+brew install openssl
+
+# Windows - usually bundled, check PATH
+```
+
+### Configuration Issues
+
+#### vx.toml Not Loading
+
+**Symptoms**: Settings in vx.toml ignored
+
+**Solutions**:
+
+```bash
+# Verify file location
+ls vx.toml
+
+# Check syntax
+vx check
+
+# Validate configuration
+vx config validate
+
+# Show effective configuration
+vx config show
+```
+
+#### Lock File Conflicts
+
+**Symptoms**: `vx.lock is out of sync`
+
+**Solutions**:
+
+```bash
+# Regenerate lock file
+vx lock --update
+
+# Or remove and regenerate
+rm vx.lock
+vx lock
+```
+
+## Diagnostic Commands
+
+### System Information
+
+```bash
+# General diagnostics
+vx doctor
+
+# System info
+vx info
+
+# Environment check
+vx check --json
+
+# Show configuration
+vx config show
+```
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+vx --debug node --version
+
+# Enable trace logging
+vx --trace node --version
+
+# Verbose output
+vx --verbose install node
+```
+
+### Cache Inspection
+
+```bash
+# Show cache location
+vx cache dir
+
+# Show cache size
+vx cache info
+
+# List cached items
+vx cache list
+
+# Clean cache
+vx cache clean
+```
+
+## Error Messages Reference
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `Tool not found` | Unknown tool name | Check `vx list` for available tools |
+| `Version not found` | Invalid version | Use `vx versions <tool>` to see available |
+| `Network error` | Connection issues | Check network, enable CDN, use mirror |
+| `Permission denied` | Insufficient permissions | Check directory permissions |
+| `Checksum mismatch` | Corrupted download | Run `vx cache clean` and retry |
+| `Out of disk space` | Disk full | Clean cache: `vx cache clean` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Tool not found |
+| 3 | Installation failed |
+| 4 | Version not found |
+| 5 | Network error |
+| 6 | Permission error |
+| 7 | Configuration error |
+
+## Recovery Procedures
+
+### Complete Reset
+
+```bash
+# Backup configuration
+cp -r ~/.vx ~/.vx.backup
+
+# Remove everything
+rm -rf ~/.vx
+
+# Reinstall
+vx install node go uv
+
+# Restore configuration
+cp ~/.vx.backup/vx.toml ~/.vx/
+```
+
+### Repair Installation
+
+```bash
+# Verify and repair
+vx doctor --fix
+
+# Reinstall all tools from vx.toml
+vx sync --force
+
+# Rebuild shims
+vx shim rebuild
+```
+
+## Getting Help
+
+### Collect Diagnostics
+
+```bash
+# Generate diagnostic report
+vx doctor --output diagnostics.txt
+
+# Include in bug report
+cat diagnostics.txt
+```
+
+### Useful Information to Provide
+
+1. vx version: `vx --version`
+2. Operating system: `vx info | grep -i os`
+3. Command that failed
+4. Error message (use `--debug`)
+5. Contents of `vx.toml` (if applicable)
+6. `vx doctor` output
+
+### Support Channels
+
+- GitHub Issues: https://github.com/loonghao/vx/issues
+- Documentation: https://github.com/loonghao/vx#readme
+
+## Quick Triage for AI Agents
+
+When a user reports a vx issue, follow this decision tree:
+
+```
+1. "command not found: vx"
+   → vx is not installed. Run the install script.
+   → Linux/macOS: curl -fsSL https://raw.githubusercontent.com/loonghao/vx/main/install.sh | bash
+   → Windows: powershell -c "irm https://raw.githubusercontent.com/loonghao/vx/main/install.ps1 | iex"
+
+2. "Failed to download" / "network error" (exit code 5)
+   → Try: vx cache clean && vx install <tool> --verbose
+   → If in China: vx config set cdn_acceleration true
+   → Check if GITHUB_TOKEN is set for API rate limits
+
+3. "version not found" (exit code 4)
+   → Run: vx versions <tool> to list available versions
+   → The user may have a typo in the version string
+   → Try: vx install <tool>@latest
+
+4. "permission denied" (exit code 6)
+   → Check: ls -la ~/.vx (Unix) or icacls %USERPROFILE%\.vx (Windows)
+   → Fix: chmod -R u+rw ~/.vx
+   → Never use sudo with vx
+
+5. Tool works but wrong version
+   → Run: vx which <tool> to see which version is active
+   → Check: vx.toml may specify a different version
+   → Run: vx switch <tool>@<version>
+
+6. vx.toml not being picked up (exit code 7)
+   → Ensure file is in the project root (same dir as .git)
+   → Run: vx check to validate syntax
+
+7. CI failing with vx
+   → Ensure the GitHub Action is used: loonghao/vx@main
+   → Add github-token for rate limit avoidance
+   → Use cache: 'true' for faster CI runs
+
+8. General error (exit code 1)
+   → Run: vx doctor for full diagnostics
+   → Run: vx --debug <command> for detailed logs
+   → Check: vx cache clean to clear corrupted state
+```

--- a/.windsurf/skills/vx-usage/SKILL.md
+++ b/.windsurf/skills/vx-usage/SKILL.md
@@ -1,0 +1,497 @@
+---
+name: vx-usage
+description: "Teaches AI agents how to use vx, the universal dev tool manager. Use when the project has vx.toml or .vx/, or when the user mentions vx, tool version management, or cross-platform setup. vx auto-manages Node.js, Python, Go, Rust, and 129 tools via Starlark DSL providers. Also covers MCP integration patterns and GitHub Actions."
+---
+
+# VX - Universal Development Tool Manager
+
+> **One-sentence summary**: vx = prefix any dev tool command with `vx` → it auto-installs the tool and runs it.
+
+vx is a universal development tool manager that automatically installs and manages
+development tools (Node.js, Python/uv, Go, Rust, etc.) with zero configuration.
+
+## Core Concept
+
+Instead of requiring users to manually install tools, prefix any command with `vx`:
+
+```bash
+vx node --version      # Auto-installs Node.js if needed
+vx uv pip install x    # Auto-installs uv if needed
+vx go build .          # Auto-installs Go if needed
+vx cargo build         # Auto-installs Rust if needed
+vx just test           # Auto-installs just if needed
+```
+
+vx is fully transparent - same commands, same arguments, just add `vx` prefix.
+
+## Essential Commands
+
+### Tool Execution (most common)
+```bash
+vx <tool> [args...]           # Run any tool (auto-installs if missing)
+vx node app.js                # Run Node.js
+vx python script.py           # Run Python (via uv)
+vx npm install                # Run npm
+vx npx create-react-app app   # Run npx
+vx cargo test                 # Run cargo
+vx just build                 # Run just (task runner)
+vx git status                 # Run git
+```
+
+### Tool Management
+```bash
+vx install node@22            # Install specific version
+vx install uv go rust         # Install multiple tools at once
+vx list                       # List all available tools
+vx list --installed           # List installed tools only
+vx versions node              # Show available versions
+vx switch node@20             # Switch active version
+vx uninstall go@1.21          # Remove a version
+```
+
+### Project Management
+```bash
+vx init                       # Initialize vx.toml for project
+vx sync                       # Install all tools from vx.toml
+vx setup                      # Full project setup (sync + hooks)
+vx dev                        # Enter dev environment with all tools
+vx run test                   # Run project scripts from vx.toml
+vx check                      # Verify tool constraints
+vx lock                       # Generate vx.lock for reproducibility
+```
+
+### Environment & Config
+```bash
+vx env list                   # List environments
+vx config show                # Show configuration
+vx cache info                 # Show cache usage
+vx search <query>             # Search available tools
+vx info                       # System info and capabilities
+```
+
+## Project Configuration (vx.toml)
+
+Projects use `vx.toml` in the root directory:
+
+```toml
+[tools]
+node = "22"         # Major version
+go = "1.22"         # Minor version
+uv = "latest"       # Always latest
+rust = "1.80"       # Specific version
+just = "*"          # Any version
+
+[scripts]
+dev = "npm run dev"
+test = "cargo test"
+lint = "npm run lint && cargo clippy"
+build = "just build"
+
+[hooks]
+pre_commit = ["vx run lint"]
+post_setup = ["npm install"]
+```
+
+## Using `--with` for Multi-Runtime
+
+When a command needs additional runtimes available:
+
+```bash
+vx --with bun node app.js     # Node.js + Bun in PATH
+vx --with deno npm test        # npm + Deno available
+```
+
+## Package Aliases
+
+vx supports **package aliases** — short commands that automatically route to ecosystem packages:
+
+```bash
+# These are equivalent:
+vx vite              # Same as: vx npm:vite
+vx vite@5.0          # Same as: vx npm:vite@5.0
+vx rez               # Same as: vx uv:rez
+vx pre-commit        # Same as: vx uv:pre-commit
+vx meson             # Same as: vx uv:meson
+vx release-please    # Same as: vx npm:release-please
+```
+
+**Benefits**:
+- Simpler commands without remembering ecosystem prefixes
+- Automatic runtime dependency management (node/python installed as needed)
+- Respects project `vx.toml` version configuration
+
+**Available Aliases**:
+| Short Command | Equivalent | Ecosystem |
+|--------------|------------|-----------|
+| `vx vite` | `vx npm:vite` | npm |
+| `vx release-please` | `vx npm:release-please` | npm |
+| `vx rez` | `vx uv:rez` | uv |
+| `vx pre-commit` | `vx uv:pre-commit` | uv |
+| `vx meson` | `vx uv:meson` | uv |
+
+## Companion Tool Environment Injection
+
+When `vx.toml` includes tools like MSVC, vx automatically injects discovery environment variables into **all** subprocess environments. This allows any tool needing a C/C++ compiler to discover the vx-managed installation.
+
+```toml
+# vx.toml — MSVC env vars injected for ALL tools
+[tools]
+node = "22"
+cmake = "3.28"
+rust = "1.82"
+
+[tools.msvc]
+version = "14.42"
+os = ["windows"]
+```
+
+Now tools like node-gyp, CMake, Cargo (cc crate) automatically find MSVC:
+
+```bash
+# node-gyp finds MSVC via VCINSTALLDIR
+vx npx node-gyp rebuild
+
+# CMake discovers the compiler
+vx cmake -B build -G "Ninja"
+
+# Cargo cc crate finds MSVC for C dependencies
+vx cargo build
+```
+
+**Injected Environment Variables** (MSVC example):
+| Variable | Purpose |
+|----------|---------|
+| `VCINSTALLDIR` | VS install path (node-gyp, CMake) |
+| `VCToolsInstallDir` | Exact toolchain path |
+| `VX_MSVC_ROOT` | vx MSVC root path |
+
+## MSVC Build Tools (Windows)
+
+Microsoft Visual C++ compiler for Windows development:
+
+```bash
+# Install MSVC Build Tools
+vx install msvc@latest
+vx install msvc 14.40       # Specific version
+
+# Using MSVC tools via namespace
+vx msvc cl main.cpp -o main.exe
+vx msvc link main.obj
+vx msvc nmake
+
+# Direct aliases
+vx cl main.cpp              # Same as: vx msvc cl
+vx nmake                    # Same as: vx msvc nmake
+
+# Version-specific usage
+vx msvc@14.40 cl main.cpp
+```
+
+**Available MSVC Tools**:
+| Tool | Command | Description |
+|------|---------|-------------|
+| cl | `vx msvc cl` | C/C++ compiler |
+| link | `vx msvc link` | Linker |
+| lib | `vx msvc lib` | Library manager |
+| nmake | `vx msvc nmake` | Make utility |
+
+## Supported Tools (129 Providers)
+
+| Category | Tools |
+|----------|-------|
+| **JavaScript** | node, npm, npx, bun, deno, pnpm, yarn, vite, nx, turbo |
+| **JS Tooling** | oxlint, biome |
+| **Python** | uv, uvx, python, pip, ruff, maturin, pre-commit |
+| **Rust** | cargo, rustc, rustup |
+| **Go** | go, gofmt, gws, goreleaser, golangci-lint |
+| **System/CLI** | git, bash, curl, pwsh, jq, yq, fd, bat, ripgrep, fzf, starship, jj, sd, eza, dust, duf, xh, atuin, zoxide, tealdeer, gping, delta, hyperfine, watchexec, bottom |
+| **TUI/Terminal** | helix, yazi, zellij, lazygit, lazydocker, k9s |
+| **Build Tools** | just, task, cmake, ninja, make, meson, xmake, protoc, buf, conan, vcpkg, spack |
+| **DevOps** | kubectl, helm, flux, kind, k3d, nerdctl, skaffold, podman, terraform, hadolint, dagu, actionlint |
+| **Security** | gitleaks, trivy, cosign, grype, syft |
+| **Cloud CLI** | awscli, azcli, gcloud |
+| **.NET** | dotnet, msbuild, nuget |
+| **C/C++** | msvc, llvm, nasm, ccache, buildcache, sccache, rcedit |
+| **Media** | ffmpeg, imagemagick |
+| **Java** | java |
+| **AI** | ollama, openclaw |
+| **Other Langs** | zig |
+| **Container** | dive |
+| **Config Mgmt** | chezmoi, mise |
+| **Package Managers** | brew, choco, winget |
+| **Data/API** | duckdb, grpcurl |
+| **Misc** | gh, prek, actrun, wix, vscode, xcodebuild, systemctl, release-please, rez, 7zip, trippy |
+
+## Provider System (Starlark DSL)
+
+All 129 providers are defined using **provider.star** (Starlark DSL) — a declarative, zero-compilation approach. Each provider lives in `crates/vx-providers/<name>/provider.star`.
+
+vx uses a **two-phase execution model** (inspired by Buck2):
+1. **Analysis Phase (Starlark)**: `provider.star` runs as pure computation, returning descriptor dicts. No I/O.
+2. **Execution Phase (Rust)**: The Rust runtime interprets descriptors for actual downloads, installs, and process execution.
+
+### How to add a new tool
+
+```starlark
+# crates/vx-providers/mytool/provider.star
+load("@vx//stdlib:provider.star", "runtime_def", "github_permissions")
+load("@vx//stdlib:provider_templates.star", "github_rust_provider")
+
+name        = "mytool"
+description = "My awesome tool"
+ecosystem   = "custom"
+
+runtimes = [runtime_def("mytool", aliases=["mt"])]
+permissions = github_permissions()
+
+# Use a template — covers 90% of tools
+_p = github_rust_provider("owner", "mytool",
+    asset = "mytool-{vversion}-{triple}.{ext}")
+fetch_versions   = _p["fetch_versions"]
+download_url     = _p["download_url"]
+install_layout   = _p["install_layout"]
+store_root       = _p["store_root"]
+get_execute_path = _p["get_execute_path"]
+environment      = _p["environment"]
+```
+
+### Available templates
+
+| Template | Use case | Example |
+|----------|----------|---------|
+| `github_rust_provider` | Rust tools on GitHub (most common) | ripgrep, fd, bat, just, uv |
+| `github_go_provider` | Go tools on GitHub (goreleaser style) | gh, task |
+| `github_binary_provider` | Single binary download (no archive) | kubectl |
+| `system_provider` | System package manager only | 7zip |
+
+### Template Placeholders
+
+| Placeholder | Rust template | Go template | Description |
+|-------------|---------------|-------------|-------------|
+| `{version}` | ✓ | ✓ | Version number (e.g., "1.0.0") |
+| `{vversion}` | ✓ | — | With v-prefix (e.g., "v1.0.0") |
+| `{triple}` | ✓ | — | Rust target triple (e.g., "x86_64-unknown-linux-musl") |
+| `{os}` | — | ✓ | Go GOOS (linux, darwin, windows) |
+| `{arch}` | — | ✓ | Go GOARCH (amd64, arm64) |
+| `{ext}` | ✓ | ✓ | Archive extension (zip/tar.gz) |
+| `{exe}` | ✓ | ✓ | Executable suffix (.exe/"") |
+
+### Starlark Standard Library (14 modules)
+
+Located in `crates/vx-starlark/stdlib/`. The main entry point is `provider.star` which re-exports everything:
+
+```starlark
+# Import everything from the unified facade
+load("@vx//stdlib:provider.star",
+     "runtime_def", "bundled_runtime_def", "dep_def",
+     "github_permissions", "platform_map",
+     "env_set", "env_prepend",
+     "archive_layout", "binary_layout")
+```
+
+Key modules:
+- `provider.star` — Unified facade (re-exports all)
+- `runtime.star` — `runtime_def`, `bundled_runtime_def`, `dep_def`
+- `platform.star` — `platform_map`, `platform_select`, `rust_triple`, `go_os_arch`
+- `env.star` — `env_set`, `env_prepend`, `env_append`, `env_unset`
+- `layout.star` — `archive_layout`, `binary_layout`, `bin_subdir_layout`, hooks
+- `provider_templates.star` — High-level templates (4 templates)
+- `permissions.star` — `github_permissions`, `system_permissions`
+- `system_install.star` — `winget_install`, `brew_install`, `apt_install`
+
+## Important Rules for AI Agents
+
+1. **Always use `vx` prefix** when running tools in vx-managed projects
+2. **Use `vx just`** instead of `just` for task runner commands
+3. **Use `vx npm`** instead of `npm` directly
+4. **Use `vx cargo`** instead of `cargo` directly
+5. **Check `vx.toml`** first to understand project tool requirements
+6. **Use `vx run <script>`** for project-defined scripts
+7. **Never suggest manual tool installation** - vx handles it automatically
+8. Commands like `vx install` are for explicit pre-installation; normal usage auto-installs
+9. **Use correct terminology**: Runtime (not Tool), Provider (not Plugin), provider.star (not provider config)
+10. **Provider development**: New tools are added via `provider.star` Starlark DSL in `crates/vx-providers/<name>/`
+11. **Tests go in `tests/` dirs** — never inline `#[cfg(test)]` in source files
+
+## Version Resolution Priority
+
+vx resolves tool versions in this order (highest to lowest):
+
+1. **Command-line override**: `vx node@22 app.js`
+2. **Project vx.toml**: `[tools] node = "22"`
+3. **Parent directory vx.toml** (traverses up to root)
+4. **User global config**: `~/.config/vx/config.toml`
+5. **Provider default**: latest stable version
+
+## MCP Integration
+
+vx is **MCP-ready** — replace `npx`/`uvx` with `vx` in MCP server configurations.
+This eliminates the "install Node.js/Python first" requirement for all MCP servers.
+
+### Configuration Pattern
+
+```json
+{
+  "mcpServers": {
+    "example-server": {
+      "command": "vx",
+      "args": ["npx", "-y", "@example/mcp-server@latest"]
+    },
+    "python-server": {
+      "command": "vx",
+      "args": ["uvx", "some-python-mcp-server@latest"]
+    }
+  }
+}
+```
+
+### Real-World MCP Examples
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+    },
+    "github": {
+      "command": "vx",
+      "args": ["npx", "-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "<token>" }
+    },
+    "sqlite": {
+      "command": "vx",
+      "args": ["uvx", "mcp-server-sqlite", "--db-path", "/path/to/db.sqlite"]
+    }
+  }
+}
+```
+
+### Migration Pattern
+
+| Original | vx-powered |
+|----------|------------|
+| `"command": "npx"` | `"command": "vx", "args": ["npx", ...]` |
+| `"command": "uvx"` | `"command": "vx", "args": ["uvx", ...]` |
+| `"command": "node"` | `"command": "vx", "args": ["node", ...]` |
+| `"command": "python"` | `"command": "vx", "args": ["python", ...]` |
+| `"command": "bun"` | `"command": "vx", "args": ["bun", ...]` |
+
+### Benefits for AI Agents
+
+- **Zero-config**: No need to check if Node.js/Python is installed before starting MCP servers
+- **Version consistency**: MCP servers always use the version specified in `vx.toml`
+- **Cross-platform**: Same MCP config works on Windows, macOS, and Linux
+- **CI/CD ready**: MCP servers in CI pipelines just work with vx
+
+## GitHub Actions Integration
+
+vx provides a GitHub Action (`action.yml`) for CI/CD workflows. Use it in `.github/workflows/` files:
+
+### Basic Usage
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    version: 'latest'           # vx version (default: latest)
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Pre-install Tools
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    tools: 'node go uv'         # Space-separated tools to pre-install
+    cache: 'true'               # Enable tool caching (default: true)
+```
+
+### Project Setup (vx.toml)
+
+```yaml
+- uses: loonghao/vx@main
+  with:
+    setup: 'true'               # Run `vx setup --ci` for vx.toml projects
+```
+
+### Full Example
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: loonghao/vx@main
+        with:
+          tools: 'node@22 uv'
+          setup: 'true'
+          cache: 'true'
+
+      - run: vx node --version
+      - run: vx npm test
+```
+
+### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | vx version to install |
+| `github-token` | `${{ github.token }}` | GitHub token for API requests |
+| `tools` | `''` | Space-separated tools to pre-install |
+| `cache` | `true` | Enable caching of ~/.vx directory |
+| `cache-key-prefix` | `vx-tools` | Custom prefix for cache key |
+| `setup` | `false` | Run `vx setup --ci` for vx.toml projects |
+
+### Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The installed vx version |
+| `cache-hit` | Whether the cache was hit |
+
+## Container Image Support
+
+vx also provides a container image for containerized workflows, and it can be consumed from Podman-compatible environments:
+
+
+```dockerfile
+# Use vx as base image
+FROM ghcr.io/loonghao/vx:latest
+
+# Tools are auto-installed on first use
+RUN vx node --version
+RUN vx uv pip install mypackage
+```
+
+### Multi-stage Build with vx
+
+```dockerfile
+FROM ghcr.io/loonghao/vx:latest AS builder
+RUN vx node --version && vx npm ci && vx npm run build
+
+FROM nginx:alpine
+COPY --from=builder /home/vx/dist /usr/share/nginx/html
+```
+
+### GitHub Actions Container Jobs
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/loonghao/vx:latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: vx node --version
+      - run: vx npm test
+```

--- a/crates/ipckit/src/cli_bridge.rs
+++ b/crates/ipckit/src/cli_bridge.rs
@@ -173,11 +173,10 @@ impl ProgressInfo {
 
     /// Get the percentage (0-100).
     pub fn percentage(&self) -> u8 {
-        if self.total == 0 {
-            0
-        } else {
-            ((self.current * 100) / self.total).min(100) as u8
-        }
+        (self.current * 100)
+            .checked_div(self.total)
+            .map(|p| p.min(100) as u8)
+            .unwrap_or(0)
     }
 }
 

--- a/crates/ipckit/src/event_stream.rs
+++ b/crates/ipckit/src/event_stream.rs
@@ -110,7 +110,7 @@ impl Event {
             serde_json::json!({
                 "current": current,
                 "total": total,
-                "percentage": if total > 0 { (current * 100) / total } else { 0 },
+                "percentage": (current * 100).checked_div(total).unwrap_or(0),
                 "message": message
             }),
         )

--- a/crates/ipckit/src/lib.rs
+++ b/crates/ipckit/src/lib.rs
@@ -47,6 +47,7 @@ pub mod shm;
 pub mod socket_server;
 pub mod task_manager;
 pub mod thread_channel;
+pub mod thread_pump;
 pub mod waker;
 
 // Async channel support
@@ -82,6 +83,7 @@ pub use task_manager::{
     TaskManagerConfig, TaskStatus,
 };
 pub use thread_channel::{ThreadChannel, ThreadReceiver, ThreadSender};
+pub use thread_pump::{MainThreadPump, PumpStats, ThreadAffinity};
 
 // API Server exports
 pub use api_server::{

--- a/crates/ipckit/src/resource_link.rs
+++ b/crates/ipckit/src/resource_link.rs
@@ -402,7 +402,7 @@ fn gc_orphans_unix(shm_dir: &str, max_age: Duration) -> usize {
             .ok()
             .map(|secs| UNIX_EPOCH + Duration::from_secs(secs))
             .and_then(|created| now.duration_since(created).ok())
-            .map_or(false, |age| age > max_age);
+            .is_some_and(|age| age > max_age);
 
         if !age_ok {
             continue;

--- a/crates/ipckit/src/task_manager.rs
+++ b/crates/ipckit/src/task_manager.rs
@@ -36,6 +36,7 @@
 
 use crate::error::{IpcError, Result};
 use crate::event_stream::{event_types, Event, EventBus, EventBusConfig, EventPublisher};
+use crate::thread_pump::ThreadAffinity;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -128,6 +129,8 @@ pub struct TaskInfo {
     pub metadata: HashMap<String, serde_json::Value>,
     /// Task labels
     pub labels: HashMap<String, String>,
+    /// Thread affinity requirement.
+    pub affinity: ThreadAffinity,
     /// Error message (if failed)
     pub error: Option<String>,
     /// Result data (if completed)
@@ -371,6 +374,8 @@ pub struct TaskBuilder {
     task_type: String,
     metadata: HashMap<String, serde_json::Value>,
     labels: HashMap<String, String>,
+    /// Thread affinity requirement for this task.
+    pub affinity: ThreadAffinity,
 }
 
 impl TaskBuilder {
@@ -381,7 +386,18 @@ impl TaskBuilder {
             task_type: task_type.to_string(),
             metadata: HashMap::new(),
             labels: HashMap::new(),
+            affinity: ThreadAffinity::Any,
         }
+    }
+
+    /// Set the thread affinity requirement for this task.
+    ///
+    /// Tasks with [`ThreadAffinity::Main`] must be executed by the host's
+    /// "main" thread and are typically driven via a
+    /// [`MainThreadPump`](crate::MainThreadPump) idle callback.
+    pub fn affinity(mut self, affinity: ThreadAffinity) -> Self {
+        self.affinity = affinity;
+        self
     }
 
     /// Add metadata to the task.
@@ -531,6 +547,7 @@ impl TaskManager {
             finished_at: None,
             metadata: builder.metadata,
             labels: builder.labels,
+            affinity: builder.affinity,
             error: None,
             result: None,
         };
@@ -961,5 +978,67 @@ mod tests {
         assert_eq!(deserialized.id, info.id);
         assert_eq!(deserialized.name, info.name);
         assert_eq!(deserialized.status, info.status);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // ThreadAffinity integration tests
+    // ────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_task_affinity_default_is_any() {
+        let manager = TaskManager::new(Default::default());
+        let handle = manager.create(TaskBuilder::new("Task", "test"));
+        assert_eq!(handle.info().affinity, ThreadAffinity::Any);
+    }
+
+    #[test]
+    fn test_task_affinity_main() {
+        use crate::MainThreadPump;
+
+        let manager = TaskManager::new(Default::default());
+        let pump = MainThreadPump::new();
+
+        // Create a task pinned to the main thread.
+        let handle = manager.create(
+            TaskBuilder::new("ui-update", "ui").affinity(ThreadAffinity::Main),
+        );
+        assert_eq!(handle.info().affinity, ThreadAffinity::Main);
+
+        // Dispatch the task start via the pump (simulating a host idle callback).
+        let h = handle.clone();
+        pump.dispatch(move || {
+            h.start();
+            h.complete(serde_json::json!({"updated": true}));
+        });
+
+        // Pump on the "main" thread.
+        let stats = pump.pump(std::time::Duration::from_millis(100));
+        assert_eq!(stats.processed, 1);
+        assert_eq!(handle.status(), TaskStatus::Completed);
+    }
+
+    #[test]
+    fn test_task_affinity_named() {
+        let manager = TaskManager::new(Default::default());
+        let handle = manager.create(
+            TaskBuilder::new("render", "render")
+                .affinity(ThreadAffinity::Named("RenderThread".into())),
+        );
+        assert_eq!(
+            handle.info().affinity,
+            ThreadAffinity::Named("RenderThread".into())
+        );
+    }
+
+    #[test]
+    fn test_task_affinity_serialization() {
+        let manager = TaskManager::new(Default::default());
+        let handle = manager.create(
+            TaskBuilder::new("Task", "test").affinity(ThreadAffinity::Main),
+        );
+        let info = handle.info();
+        let json = serde_json::to_string(&info).unwrap();
+        let deserialized: TaskInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.affinity, ThreadAffinity::Main);
     }
 }

--- a/crates/ipckit/src/task_manager.rs
+++ b/crates/ipckit/src/task_manager.rs
@@ -999,9 +999,8 @@ mod tests {
         let pump = MainThreadPump::new();
 
         // Create a task pinned to the main thread.
-        let handle = manager.create(
-            TaskBuilder::new("ui-update", "ui").affinity(ThreadAffinity::Main),
-        );
+        let handle =
+            manager.create(TaskBuilder::new("ui-update", "ui").affinity(ThreadAffinity::Main));
         assert_eq!(handle.info().affinity, ThreadAffinity::Main);
 
         // Dispatch the task start via the pump (simulating a host idle callback).
@@ -1033,9 +1032,8 @@ mod tests {
     #[test]
     fn test_task_affinity_serialization() {
         let manager = TaskManager::new(Default::default());
-        let handle = manager.create(
-            TaskBuilder::new("Task", "test").affinity(ThreadAffinity::Main),
-        );
+        let handle =
+            manager.create(TaskBuilder::new("Task", "test").affinity(ThreadAffinity::Main));
         let info = handle.info();
         let json = serde_json::to_string(&info).unwrap();
         let deserialized: TaskInfo = serde_json::from_str(&json).unwrap();

--- a/crates/ipckit/src/thread_pump.rs
+++ b/crates/ipckit/src/thread_pump.rs
@@ -70,7 +70,7 @@ use std::time::{Duration, Instant};
 /// let builder = TaskBuilder::new("render", "render")
 ///     .affinity(ThreadAffinity::Main);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ThreadAffinity {
     /// Task must run on the host "main" thread (UI thread in DCC apps).
     ///
@@ -85,13 +85,8 @@ pub enum ThreadAffinity {
     Named(String),
 
     /// Any worker thread is acceptable.  This is the default.
+    #[default]
     Any,
-}
-
-impl Default for ThreadAffinity {
-    fn default() -> Self {
-        Self::Any
-    }
 }
 
 impl ThreadAffinity {

--- a/crates/ipckit/src/thread_pump.rs
+++ b/crates/ipckit/src/thread_pump.rs
@@ -179,7 +179,10 @@ impl MainThreadPump {
     {
         self.inner.pending.fetch_add(1, Ordering::Relaxed);
         self.inner.total_dispatched.fetch_add(1, Ordering::Relaxed);
-        self.inner.tx.send(Box::new(f)).expect("pump receiver dropped");
+        self.inner
+            .tx
+            .send(Box::new(f))
+            .expect("pump receiver dropped");
     }
 
     /// Drain pending work items for up to `budget` wall-clock time.
@@ -265,10 +268,7 @@ mod tests {
     fn test_thread_affinity_thread_name() {
         assert!(ThreadAffinity::Any.thread_name().is_none());
         assert!(ThreadAffinity::Main.thread_name().is_none());
-        assert_eq!(
-            ThreadAffinity::Named("GT".into()).thread_name(),
-            Some("GT")
-        );
+        assert_eq!(ThreadAffinity::Named("GT".into()).thread_name(), Some("GT"));
     }
 
     #[test]

--- a/crates/ipckit/src/thread_pump.rs
+++ b/crates/ipckit/src/thread_pump.rs
@@ -1,0 +1,384 @@
+//! Thread affinity and cooperative main-thread pump for `TaskManager`.
+//!
+//! Most DCC and game-engine host APIs are **UI / main-thread pinned** — calling
+//! them from a worker thread either throws or causes a segfault.  This module
+//! adds a first-class `ThreadAffinity` concept to the [`TaskManager`] ecosystem
+//! and a cooperative [`MainThreadPump`] so the host can drain the main-thread
+//! work queue from its own idle callback.
+//!
+//! # Design
+//!
+//! - Yield points are **cooperative**: a task must periodically check
+//!   [`TaskHandle::is_cancelled`] or simply complete quickly.  There is no
+//!   pre-emption, mirroring the Go scheduler and Unity's `EditorApplication`.
+//! - [`MainThreadPump::pump`] drains work items up to a wall-clock `budget`
+//!   — it never blocks longer than that, keeping the host's frame rate intact.
+//!
+//! # DCC host integration examples
+//!
+//! | Host | Idle callback |
+//! |---|---|
+//! | Maya | `cmds.scriptJob(idleEvent=pump_fn)` |
+//! | Houdini | `hdefereval.execute_deferred_after_waiting` |
+//! | 3dsMax | `pymxs.run_at_ui_idle` |
+//! | Blender | `bpy.app.timers.register` |
+//! | Unity Editor | `EditorApplication.update` |
+//! | Unreal | `FTSTicker` / `AsyncTask(ENamedThreads::GameThread, …)` |
+//!
+//! # Example
+//!
+//! ```rust
+//! use ipckit::{MainThreadPump, ThreadAffinity, TaskManager, TaskBuilder};
+//! use std::time::Duration;
+//!
+//! let manager = TaskManager::new(Default::default());
+//! let pump = MainThreadPump::new();
+//!
+//! // Register a "main-thread" task
+//! let handle = manager.create(
+//!     TaskBuilder::new("update-ui", "ui")
+//!         .affinity(ThreadAffinity::Main)
+//! );
+//!
+//! // Dispatch work to the main thread
+//! pump.dispatch(move || {
+//!     handle.start();
+//!     handle.complete(serde_json::json!({"updated": true}));
+//! });
+//!
+//! // In the host idle callback:
+//! let stats = pump.pump(Duration::from_millis(8));
+//! assert_eq!(stats.processed, 1);
+//! ```
+
+use crossbeam_channel as cb;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+// ── ThreadAffinity ────────────────────────────────────────────────────────────
+
+/// Controls which thread a task must execute on.
+///
+/// Attach to a [`TaskBuilder`](crate::TaskBuilder) via
+/// [`TaskBuilder::affinity`]:
+///
+/// ```rust
+/// use ipckit::{TaskBuilder, ThreadAffinity};
+///
+/// let builder = TaskBuilder::new("render", "render")
+///     .affinity(ThreadAffinity::Main);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ThreadAffinity {
+    /// Task must run on the host "main" thread (UI thread in DCC apps).
+    ///
+    /// The `TaskManager`/host is responsible for draining these tasks via
+    /// [`MainThreadPump::pump`].
+    Main,
+
+    /// Task must run on a named thread (e.g. `"RenderThread"` in Unreal).
+    ///
+    /// The string is an arbitrary tag agreed upon by the producer and the
+    /// host; ipckit does not validate it.
+    Named(String),
+
+    /// Any worker thread is acceptable.  This is the default.
+    Any,
+}
+
+impl Default for ThreadAffinity {
+    fn default() -> Self {
+        Self::Any
+    }
+}
+
+impl ThreadAffinity {
+    /// Returns `true` if this affinity requires a specific thread.
+    pub fn is_pinned(&self) -> bool {
+        !matches!(self, Self::Any)
+    }
+
+    /// Returns the thread name for `Named` variants; `None` otherwise.
+    pub fn thread_name(&self) -> Option<&str> {
+        match self {
+            Self::Named(n) => Some(n.as_str()),
+            _ => None,
+        }
+    }
+}
+
+// ── PumpStats ─────────────────────────────────────────────────────────────────
+
+/// Statistics returned by a single [`MainThreadPump::pump`] call.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct PumpStats {
+    /// Number of work items processed in this pump call.
+    pub processed: usize,
+    /// Elapsed wall-clock time.
+    pub elapsed: Duration,
+    /// Number of items still waiting after this pump call.
+    pub remaining: usize,
+}
+
+// ── MainThreadPump ────────────────────────────────────────────────────────────
+
+type WorkFn = Box<dyn FnOnce() + Send + 'static>;
+
+struct PumpInner {
+    tx: cb::Sender<WorkFn>,
+    pending: AtomicUsize,
+    total_dispatched: AtomicU64,
+    total_processed: AtomicU64,
+}
+
+/// Cooperative pump that drains main-thread work items on demand.
+///
+/// [`MainThreadPump`] is `Clone` — all clones share the same underlying queue.
+/// The instance that calls [`pump`](Self::pump) must be on the affinity thread.
+///
+/// # Thread safety
+///
+/// [`dispatch`](Self::dispatch) is safe to call from any thread.
+/// [`pump`](Self::pump) must be called from the thread that "owns" the pump
+/// (typically the DCC main / UI thread).
+#[derive(Clone)]
+pub struct MainThreadPump {
+    inner: Arc<PumpInner>,
+    rx: Arc<cb::Receiver<WorkFn>>,
+}
+
+impl MainThreadPump {
+    /// Create a new pump with an unbounded internal queue.
+    pub fn new() -> Self {
+        let (tx, rx) = cb::unbounded();
+        Self {
+            inner: Arc::new(PumpInner {
+                tx,
+                pending: AtomicUsize::new(0),
+                total_dispatched: AtomicU64::new(0),
+                total_processed: AtomicU64::new(0),
+            }),
+            rx: Arc::new(rx),
+        }
+    }
+
+    /// Dispatch a closure to run on the affinity thread.
+    ///
+    /// Returns immediately; the closure will be executed on the next
+    /// [`pump`](Self::pump) call.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the pump has been dropped (the receiver end is gone).  In
+    /// normal usage this never happens while any clone is alive.
+    pub fn dispatch<F>(&self, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.inner.pending.fetch_add(1, Ordering::Relaxed);
+        self.inner.total_dispatched.fetch_add(1, Ordering::Relaxed);
+        self.inner.tx.send(Box::new(f)).expect("pump receiver dropped");
+    }
+
+    /// Drain pending work items for up to `budget` wall-clock time.
+    ///
+    /// Call this from the host's idle / update callback.  The pump will
+    /// process as many items as possible within the budget without
+    /// over-running it (each item runs to completion; the budget is checked
+    /// *between* items).
+    ///
+    /// Returns [`PumpStats`] describing what happened.
+    pub fn pump(&self, budget: Duration) -> PumpStats {
+        let start = Instant::now();
+        let mut processed = 0;
+
+        loop {
+            // Check budget *before* dequeuing.
+            if start.elapsed() >= budget {
+                break;
+            }
+
+            match self.rx.try_recv() {
+                Ok(f) => {
+                    f();
+                    self.inner.pending.fetch_sub(1, Ordering::Relaxed);
+                    self.inner.total_processed.fetch_add(1, Ordering::Relaxed);
+                    processed += 1;
+                }
+                Err(cb::TryRecvError::Empty) => break,
+                Err(cb::TryRecvError::Disconnected) => break,
+            }
+        }
+
+        PumpStats {
+            processed,
+            elapsed: start.elapsed(),
+            remaining: self.inner.pending.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Number of work items currently waiting to be pumped.
+    pub fn pending(&self) -> usize {
+        self.inner.pending.load(Ordering::Relaxed)
+    }
+
+    /// Total number of closures ever dispatched since this pump was created.
+    pub fn total_dispatched(&self) -> u64 {
+        self.inner.total_dispatched.load(Ordering::Relaxed)
+    }
+
+    /// Total number of closures ever processed since this pump was created.
+    pub fn total_processed(&self) -> u64 {
+        self.inner.total_processed.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for MainThreadPump {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU32;
+    use std::thread;
+
+    #[test]
+    fn test_thread_affinity_default_is_any() {
+        assert_eq!(ThreadAffinity::default(), ThreadAffinity::Any);
+    }
+
+    #[test]
+    fn test_thread_affinity_is_pinned() {
+        assert!(!ThreadAffinity::Any.is_pinned());
+        assert!(ThreadAffinity::Main.is_pinned());
+        assert!(ThreadAffinity::Named("RenderThread".into()).is_pinned());
+    }
+
+    #[test]
+    fn test_thread_affinity_thread_name() {
+        assert!(ThreadAffinity::Any.thread_name().is_none());
+        assert!(ThreadAffinity::Main.thread_name().is_none());
+        assert_eq!(
+            ThreadAffinity::Named("GT".into()).thread_name(),
+            Some("GT")
+        );
+    }
+
+    #[test]
+    fn test_thread_affinity_serialization() {
+        let variants = [
+            ThreadAffinity::Any,
+            ThreadAffinity::Main,
+            ThreadAffinity::Named("Render".into()),
+        ];
+        for v in &variants {
+            let json = serde_json::to_string(v).unwrap();
+            let back: ThreadAffinity = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, v);
+        }
+    }
+
+    #[test]
+    fn test_pump_basic() {
+        let pump = MainThreadPump::new();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        let c = Arc::clone(&counter);
+        pump.dispatch(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        });
+
+        assert_eq!(pump.pending(), 1);
+        let stats = pump.pump(Duration::from_millis(100));
+        assert_eq!(stats.processed, 1);
+        assert_eq!(stats.remaining, 0);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_pump_multiple_items() {
+        let pump = MainThreadPump::new();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        for _ in 0..5 {
+            let c = Arc::clone(&counter);
+            pump.dispatch(move || {
+                c.fetch_add(1, Ordering::SeqCst);
+            });
+        }
+
+        let stats = pump.pump(Duration::from_millis(500));
+        assert_eq!(stats.processed, 5);
+        assert_eq!(counter.load(Ordering::SeqCst), 5);
+        assert_eq!(pump.total_dispatched(), 5);
+        assert_eq!(pump.total_processed(), 5);
+    }
+
+    #[test]
+    fn test_pump_budget_zero_processes_nothing() {
+        let pump = MainThreadPump::new();
+        pump.dispatch(|| {});
+
+        // A zero budget may or may not process items depending on timing;
+        // use a tiny positive budget that should still be exceeded quickly.
+        // The important thing is it must not block.
+        let _ = pump.pump(Duration::ZERO);
+        // Pump a second time to clean up.
+        pump.pump(Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_pump_cross_thread_dispatch() {
+        let pump = MainThreadPump::new();
+        let pump_worker = pump.clone();
+        let counter = Arc::new(AtomicU32::new(0));
+        let c = Arc::clone(&counter);
+
+        // Dispatch from a worker thread.
+        let handle = thread::spawn(move || {
+            pump_worker.dispatch(move || {
+                c.fetch_add(42, Ordering::SeqCst);
+            });
+        });
+        handle.join().unwrap();
+
+        // Pump on the "main" thread.
+        pump.pump(Duration::from_millis(100));
+        assert_eq!(counter.load(Ordering::SeqCst), 42);
+    }
+
+    #[test]
+    fn test_pump_stats_elapsed_is_reasonable() {
+        let pump = MainThreadPump::new();
+        // Queue a slow item.
+        pump.dispatch(|| thread::sleep(Duration::from_millis(20)));
+
+        let stats = pump.pump(Duration::from_millis(500));
+        assert_eq!(stats.processed, 1);
+        assert!(stats.elapsed >= Duration::from_millis(15)); // some tolerance
+    }
+
+    #[test]
+    fn test_pump_clone_shares_queue() {
+        let pump1 = MainThreadPump::new();
+        let pump2 = pump1.clone();
+        let counter = Arc::new(AtomicU32::new(0));
+
+        let c = Arc::clone(&counter);
+        pump2.dispatch(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        });
+
+        // pump1 drains the item dispatched via pump2.
+        let stats = pump1.pump(Duration::from_millis(100));
+        assert_eq!(stats.processed, 1);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #47

Adds a first-class `ThreadAffinity` concept to `TaskManager`/`TaskBuilder` and a cooperative `MainThreadPump` so that DCC and game-engine hosts can safely drive ipckit tasks from their UI/main thread without introducing a separate broker process or any extra dependencies.

## Problem

Every serious DCC/engine host requires **main-thread pinning** for UI calls:
- Maya `cmds.*` — only safe from the UI thread
- Houdini `hou.*` — same
- Unreal `GameThread` — required for most engine calls
- Blender `bpy.ops.*` — must run from the main thread

Without first-class affinity support, every user re-invents the same `Mutex<VecDeque<Box<dyn FnOnce>>>` pattern and inevitably gets deadlocks.

## Solution

### `ThreadAffinity` (new enum, re-exported from crate root)

```rust
pub enum ThreadAffinity {
    Main,                        // UI / host main thread
    Named(String),               // e.g. "RenderThread" in Unreal
    Any,                         // any worker (default)
}
```

### `TaskBuilder::affinity()`

```rust
let handle = manager.create(
    TaskBuilder::new("update-ui", "ui")
        .affinity(ThreadAffinity::Main)
);
// handle.info().affinity == ThreadAffinity::Main (serialisable)
```

### `MainThreadPump` (new struct, re-exported from crate root)

```rust
let pump = MainThreadPump::new();            // create once

// From any thread:
pump.dispatch(|| do_main_thread_work());

// From the host idle callback (Maya scriptJob, Unity update, …):
let stats = pump.pump(Duration::from_millis(8));
// PumpStats { processed: 1, elapsed: …, remaining: 0 }
```

`MainThreadPump` is `Clone` — all clones share the same queue.

## DCC host wiring table

| Host | Idle callback |
|---|---|
| Maya | `cmds.scriptJob(idleEvent=pump_fn)` |
| Houdini | `hdefereval.execute_deferred_after_waiting` |
| 3dsMax | `pymxs.run_at_ui_idle` |
| Blender | `bpy.app.timers.register` |
| Unity Editor | `EditorApplication.update` |
| Unreal | `FTSTicker` / `AsyncTask(ENamedThreads::GameThread, …)` |

## Exports

`ThreadAffinity`, `MainThreadPump`, `PumpStats` re-exported from the crate root.

`TaskInfo` gains an `affinity: ThreadAffinity` field (fully serialisable).

## Test plan

- [x] `cargo test -p ipckit --lib` — **132 tests pass (14 new)**
- [x] `test_thread_affinity_*` — enum variants, `is_pinned`, `thread_name`, serde
- [x] `test_pump_*` — basic, multiple items, zero budget, cross-thread dispatch, stats, clone sharing
- [x] `test_task_affinity_*` — default, Main + pump round-trip, Named, serde round-trip